### PR TITLE
[Apollo GraphQL] Day 5: Data Sources   (Feature#58550)

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "license": "ISC",
   "homepage": "https://bitbucket.org/rahuls-nx/apollo-training#readme",
   "dependencies": {
+    "@amcharts/amcharts4": "^4.10.22",
     "@babel/preset-react": "^7.16.0",
     "apollo-server-express": "^2.11.0",
     "body-parser": "^1.19.0",
@@ -35,6 +36,7 @@
     "eslint": "^8.2.0",
     "express": "^4.17.1",
     "graphql": "^14.6.0",
+    "graphql-subscriptions": "^2.0.0",
     "helmet": "^3.22.0",
     "husky": "^7.0.4",
     "joi": "^14.3.1",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@amcharts/amcharts4": "^4.10.22",
     "@babel/preset-react": "^7.16.0",
+    "apollo-datasource-rest": "^3.4.0",
     "apollo-server-express": "^2.11.0",
     "body-parser": "^1.19.0",
     "compression": "^1.7.4",

--- a/src/config/configurations.js
+++ b/src/config/configurations.js
@@ -10,6 +10,8 @@ const envVarsSchema = Joi.object({
     .default('development'),
   PORT: Joi.number()
     .default(9001),
+  SERVICE_URL: Joi.string()
+    .default('http://localhost:9000'),
 }).unknown()
   .required();
 
@@ -18,6 +20,7 @@ const { value: envVars } = Joi.validate(process.env, envVarsSchema);
 const configurations = Object.freeze({
   env: envVars.NODE_ENV,
   port: envVars.PORT,
+  serviceUrl: envVars.SERVICE_URL,
 });
 
 export default configurations;

--- a/src/config/configurations.js
+++ b/src/config/configurations.js
@@ -20,7 +20,9 @@ const { value: envVars } = Joi.validate(process.env, envVarsSchema);
 const configurations = Object.freeze({
   env: envVars.NODE_ENV,
   port: envVars.PORT,
+  secret: process.env.TOKEN_SECRET,
   serviceUrl: envVars.SERVICE_URL,
+  password: process.env.PASSWORD,
 });
 
 export default configurations;

--- a/src/datasource/index.js
+++ b/src/datasource/index.js
@@ -1,0 +1,4 @@
+import Trainee from './trainee';
+import User from './user';
+
+export { Trainee, User };

--- a/src/datasource/trainee.js
+++ b/src/datasource/trainee.js
@@ -1,0 +1,25 @@
+import { RESTDataSource } from 'apollo-datasource-rest';
+import config from '../config/configurations';
+
+export class TraineeAPI extends RESTDataSource {
+  constructor() {
+    super();
+    this.baseURL = `${config.serviceUrl}/api/trainee`;
+  }
+
+  async getTrainee(limit, skip) {
+    return this.get('/', { limit, skip });
+  }
+
+  async createTrainee(payload) {
+    return this.post('/', payload);
+  }
+
+  async updateTrainee(payload) {
+    return this.put('/', payload);
+  }
+
+  async deleteTrainee(id) {
+    return this.delete(`/${id}`);
+  }
+}

--- a/src/datasource/user.js
+++ b/src/datasource/user.js
@@ -4,7 +4,7 @@ import config from '../config/configurations';
 export class UserAPI extends RESTDataSource {
   constructor() {
     super();
-    this.baseURL = `${config.serviceUrl}/api/user`;
+    this.baseURL = `${config.serviceUrl}/api/trainee`;
   }
 
   getMe() {
@@ -12,7 +12,7 @@ export class UserAPI extends RESTDataSource {
   }
 
   async loginUser(payload) {
-    return this.post('/login', payload);
+    return this.post('/createToken', payload);
   }
 
   async updateTrainee(payload) {

--- a/src/datasource/user.js
+++ b/src/datasource/user.js
@@ -1,0 +1,25 @@
+import { RESTDataSource } from 'apollo-datasource-rest';
+import config from '../config/configurations';
+
+export class UserAPI extends RESTDataSource {
+  constructor() {
+    super();
+    this.baseURL = `${config.serviceUrl}/api/user`;
+  }
+
+  getMe() {
+    return this.get('/me');
+  }
+
+  async loginUser(payload) {
+    return this.post('/login', payload);
+  }
+
+  async updateTrainee(payload) {
+    return this.put('/', payload);
+  }
+
+  async deleteTrainee(id) {
+    return this.delete(`/${id}`);
+  }
+}

--- a/src/lib/constant.js
+++ b/src/lib/constant.js
@@ -1,0 +1,7 @@
+export default {
+  subscriptions: {
+    TRAINEE_ADDED: 'TRAINEE_ADDED',
+    TRAINEE_UPDATED: 'TRAINEE_UPDATED',
+    TRAINEE_DELETED: 'TRAINEE_DELETED',
+  },
+};

--- a/src/module/index.js
+++ b/src/module/index.js
@@ -2,6 +2,7 @@ import { fileLoader, mergeTypes } from 'merge-graphql-schemas';
 import path from 'path';
 
 import * as user from './user';
+import * as Mutation from './trainee';
 
 const typesArray = fileLoader(path.join(__dirname, './**/*.graphql'));
 
@@ -11,6 +12,9 @@ export default {
   resolvers: {
     Query: {
       ...user.Query,
+    },
+    Mutation: {
+      ...Mutation.Mutation,
     },
   },
   typeDefs,

--- a/src/module/index.js
+++ b/src/module/index.js
@@ -1,24 +1,27 @@
 import { fileLoader, mergeTypes } from 'merge-graphql-schemas';
 import path from 'path';
-
+import * as trainee from './trainee';
 import * as user from './user';
-import * as Mutation from './trainee';
 
 const typesArray = fileLoader(path.join(__dirname, './**/*.graphql'));
-
+console.log('typesArray ---->', typesArray);
+// console.log('typesArray Query', typesArray.Query);
+console.log('user', user);
 const typeDefs = mergeTypes(typesArray, { all: true });
+console.log('typeDefs ---->', typeDefs);
+console.log('user.getMyProfile ---->', user);
 
 export default {
   resolvers: {
     Query: {
       ...user.Query,
+      ...trainee.Query,
     },
     Mutation: {
-      ...Mutation.Mutation,
+      ...trainee.Mutation,
     },
     Subscription: {
-      ...Mutation.Subscriptions,
-
+      ...trainee.Subscription,
     },
   },
   typeDefs,

--- a/src/module/index.js
+++ b/src/module/index.js
@@ -4,12 +4,8 @@ import * as trainee from './trainee';
 import * as user from './user';
 
 const typesArray = fileLoader(path.join(__dirname, './**/*.graphql'));
-console.log('typesArray ---->', typesArray);
 // console.log('typesArray Query', typesArray.Query);
-console.log('user', user);
 const typeDefs = mergeTypes(typesArray, { all: true });
-console.log('typeDefs ---->', typeDefs);
-console.log('user.getMyProfile ---->', user);
 
 export default {
   resolvers: {
@@ -19,6 +15,7 @@ export default {
     },
     Mutation: {
       ...trainee.Mutation,
+      ...user.Mutation,
     },
     Subscription: {
       ...trainee.Subscription,

--- a/src/module/index.js
+++ b/src/module/index.js
@@ -16,6 +16,10 @@ export default {
     Mutation: {
       ...Mutation.Mutation,
     },
+    Subscription: {
+      ...Mutation.Subscriptions,
+
+    },
   },
   typeDefs,
 };

--- a/src/module/pubsub.js
+++ b/src/module/pubsub.js
@@ -1,0 +1,3 @@
+import { PubSub } from 'graphql-subscriptions';
+
+export default new PubSub();

--- a/src/module/schema.graphql
+++ b/src/module/schema.graphql
@@ -1,3 +1,11 @@
 type Query {
   getMyProfile: User!
+  getAllTrainees: [User]
+  getTrainee(id: ID!): User!
+}
+
+type Mutation {
+  createTrainee(user: CreateUserInput) : User!
+  updateTrainee(id: ID!, role: String!) :User!
+  deleteTrainee(id: ID!) : ID!
 }

--- a/src/module/schema.graphql
+++ b/src/module/schema.graphql
@@ -8,6 +8,7 @@ type Mutation {
   createTrainee(user: CreateUserInput) : User!
   updateTrainee(id: ID!, role: String!) :User!
   deleteTrainee(id: ID!) : ID!
+  loginUser(payload: UserInput) : loginResponse!
 }
 
 type Subscription {

--- a/src/module/schema.graphql
+++ b/src/module/schema.graphql
@@ -9,3 +9,9 @@ type Mutation {
   updateTrainee(id: ID!, role: String!) :User!
   deleteTrainee(id: ID!) : ID!
 }
+
+type Subscription {
+  traineeAdded: User!
+  traineeUpdated: User!
+  traineeDeleted: ID!
+}

--- a/src/module/trainee/index.js
+++ b/src/module/trainee/index.js
@@ -1,0 +1,2 @@
+export { default as Query } from './query';
+export { default as Mutation } from './mutation';

--- a/src/module/trainee/index.js
+++ b/src/module/trainee/index.js
@@ -1,2 +1,3 @@
 export { default as Query } from './query';
 export { default as Mutation } from './mutation';
+export { default as Subscriptions } from './subscription';

--- a/src/module/trainee/mutation.js
+++ b/src/module/trainee/mutation.js
@@ -1,0 +1,16 @@
+import userInstance from '../../service/user';
+
+export default {
+  createTrainee: (parent, args) => {
+    const { user } = args;
+    return userInstance.createUser(user);
+  },
+  updateTrainee: (parent, args) => {
+    const { id, role } = args;
+    return userInstance.updateUser(id, role);
+  },
+  deleteTrainee: (parent, args) => {
+    const { id } = args;
+    return userInstance.deleteUser(id);
+  },
+};

--- a/src/module/trainee/mutation.js
+++ b/src/module/trainee/mutation.js
@@ -1,16 +1,24 @@
+import pubsub from '../pubsub';
+import constant from '../../lib/constant';
 import userInstance from '../../service/user';
 
 export default {
   createTrainee: (parent, args) => {
     const { user } = args;
-    return userInstance.createUser(user);
+    const addUser = userInstance.createUser(user);
+    pubsub.publish(constant.subscriptions.TRAINEE_ADDED, { traineeAdded: addUser });
+    return addUser;
   },
   updateTrainee: (parent, args) => {
     const { id, role } = args;
-    return userInstance.updateUser(id, role);
+    const updateUser = userInstance.updateUser(id, role);
+    pubsub.publish(constant.subscriptions.TRAINEE_UPDATED, { traineeUpdated: updateUser });
+    return updateUser;
   },
   deleteTrainee: (parent, args) => {
     const { id } = args;
-    return userInstance.deleteUser(id);
+    const deletedId = userInstance.deleteUser(id);
+    pubsub.publish(constant.subscriptions.TRAINEE_DELETED, { traineeDeleted: deletedId });
+    return deletedId;
   },
 };

--- a/src/module/trainee/query.js
+++ b/src/module/trainee/query.js
@@ -1,0 +1,9 @@
+import user from '../../service/user';
+
+export default {
+  getAllTrainees: () => user.getAllTrainees(),
+  getTrainee: (parent, args) => {
+    const { id } = args;
+    return user.getUser(id);
+  },
+};

--- a/src/module/trainee/subscription.js
+++ b/src/module/trainee/subscription.js
@@ -1,0 +1,14 @@
+import constant from '../../lib/constant';
+import pubsub from '../pubsub';
+
+export default {
+  traineeAdded: {
+    subscribe: () => pubsub.asyncIterator([constant.subscriptions.TRAINEE_ADDED]),
+  },
+  traineeUpdated: {
+    subscribe: () => pubsub.asyncIterator([constant.subscriptions.TRAINEE_UPDATED]),
+  },
+  traineeDeleted: {
+    subscribe: () => pubsub.asyncIterator([constant.subscriptions.TRAINEE_DELETED]),
+  },
+};

--- a/src/module/trainee/types.graphql
+++ b/src/module/trainee/types.graphql
@@ -1,0 +1,5 @@
+input CreateUserInput{
+    name: String!
+    email: String!
+    role: String!
+}

--- a/src/module/user/index.js
+++ b/src/module/user/index.js
@@ -1,1 +1,2 @@
 export { default as Query } from './query';
+export { default as Mutation } from './mutation';

--- a/src/module/user/mutation.js
+++ b/src/module/user/mutation.js
@@ -1,11 +1,11 @@
 export default {
   loginUser: async (parent, args, context) => {
     const { payload: { email, password } } = args;
-    // console.log('args ---> ',args);
+    console.log('args ---> ', args);
     const { dataSources: { userAPI } } = context;
     // console.log('UserAPI context ---> ',context);
     const response = await userAPI.loginUser({ email, password });
     console.log('response---> ', response);
-    return response.data;
+    return response;
   },
 };

--- a/src/module/user/mutation.js
+++ b/src/module/user/mutation.js
@@ -1,0 +1,11 @@
+export default {
+  loginUser: async (parent, args, context) => {
+    const { payload: { email, password } } = args;
+    // console.log('args ---> ',args);
+    const { dataSources: { userAPI } } = context;
+    // console.log('UserAPI context ---> ',context);
+    const response = await userAPI.loginUser({ email, password });
+    console.log('response---> ', response);
+    return response.data;
+  },
+};

--- a/src/module/user/query.js
+++ b/src/module/user/query.js
@@ -1,7 +1,7 @@
 export default {
-  getMyProfile: () => ({
-    id: 1,
-    name: 'Shobhit Dwivedi',
-    email: 'shobhit.dwivedi@successive.tech',
-  }),
+  getMyProfile: async (parent, args, context) => {
+    const response = await context.dataSources.userAPI.getMe();
+    console.log('response for get my profile query ---> ', response.data[0].email);
+    return { email: response.data[0].email };
+  },
 };

--- a/src/module/user/types.graphql
+++ b/src/module/user/types.graphql
@@ -2,4 +2,5 @@ type User {
   id: ID!
   name: String!
   email: String!
+  role: String!
 }

--- a/src/module/user/types.graphql
+++ b/src/module/user/types.graphql
@@ -17,3 +17,9 @@ input UserInput{
 type Token{
     token: String!
 }
+
+type loginResponse{
+    message: String!
+    data: Token
+    status: String!
+}

--- a/src/module/user/types.graphql
+++ b/src/module/user/types.graphql
@@ -1,6 +1,19 @@
 type User {
-  id: ID!
-  name: String!
-  email: String!
-  role: String!
+    id: ID!
+    name: String!
+    email: String!
+    role:String!
+}
+
+type Email{
+    email: String
+}
+
+input UserInput{
+    email: String!
+    password: String!
+}
+
+type Token{
+    token: String!
 }

--- a/src/server.js
+++ b/src/server.js
@@ -8,6 +8,8 @@ import Express from 'express';
 import helmet from 'helmet';
 import methodOverride from 'method-override';
 import { ApolloServer } from 'apollo-server-express';
+import { UserAPI } from './datasource/user';
+import { TraineeAPI } from './datasource/trainee';
 
 export default class Server {
   constructor(config) {
@@ -52,6 +54,10 @@ export default class Server {
 
     this.server = new ApolloServer({
       ...schema,
+      dataSources: () => ({
+        userAPI: new UserAPI(),
+        traineeAPI: new TraineeAPI(),
+      }),
       onHealthCheck: () => new Promise((resolve) => {
         resolve('I am OK');
       }),

--- a/src/service/user.js
+++ b/src/service/user.js
@@ -1,0 +1,33 @@
+class User {
+  constructor() {
+    this.users = new Map();
+    this.id = 0;
+  }
+
+  getAllUsers() {
+    return this.users;
+  }
+
+  getUser(id) {
+    return this.users.get(Number(id));
+  }
+
+  createUser(user) {
+    this.id += 1;
+    this.users.set(this.id, { ...user, id: this.id });
+    return this.users.get(this.id);
+  }
+
+  updateUser(id, role) {
+    const user = this.users.get(Number(id));
+    this.users.set(Number(id), { ...user, role });
+    return this.users.get(Number(id));
+  }
+
+  deleteUser(id) {
+    this.users.delete(Number(id));
+    return id;
+  }
+}
+
+export default new User();


### PR DESCRIPTION
Create a class UserAPI in datasource/User.js which will be extending RestDataSource exported from apollo-datasource-rest package.
In the constructor assign your data source a base URL (`${config.serviceUrl}/api/user`).
Define two methods getMe and loginUser with credentials argument (notice that we are creating methods for which we have endpoints available in our service).
Add definition to the above methods where you will be calling your API for ex. (/login) and export this class.
Import it in the server file where we will be passing the instance of this class while creating the instance of the Apollo Server as dataSources.
Assuming that you have already defined loginUser in the schema, we will create its resolver where we will get the arguments and dataSources from the context and we will call the loginUser method of the dataSource by providing credentials as an argument.
